### PR TITLE
Small bugfix for dark filter while reading pdf

### DIFF
--- a/defaults/preferences/options.js
+++ b/defaults/preferences/options.js
@@ -1,2 +1,3 @@
 // pref('extensions.night.default_pdf', 'match')
 // pref('extensions.night.enabled', 'true')
+// pref('extensions.zotero.night.enabled', 'true')


### PR DESCRIPTION
 Added extensions.zotero.night.enabled - true to config. The fix is described in [BUG] Plugin seems to not save preferences correctly #64 and further referenced in [BUG] Dark filter not working in pdf reader #78